### PR TITLE
feat: 記事削除ツール追加と下書きフラグのAtomPub準拠修正

### DIFF
--- a/.kiro/specs/hatena-blog-mcp-server/design.md
+++ b/.kiro/specs/hatena-blog-mcp-server/design.md
@@ -179,6 +179,7 @@ MCPクライアントに公開されるツール：
 | update_blog_post | 記事更新 | post_id: str, title: str, content: str | post_url: str, updated_at: str |
 | get_blog_post | 記事取得 | post_id: str | title: str, content: str, categories: list[str] |
 | list_blog_posts | 記事一覧取得 | limit: int | posts: list[BlogPost] |
+| delete_blog_post | 記事削除 | post_id: str（簡単ID/完全ID） | success: bool |
 
 #### Optional Tools (Markdown)
 | Tool Name | Purpose | Parameters | Returns |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,6 +62,8 @@ Kiro-style Spec Driven Development implementation using claude code slash comman
 11. **Session structure**: Separate AI-assisted work from human project management tasks
 12. **Reference analysis**: Research similar projects during design phase
 13. **Library verification**: Test imports and usage patterns before main implementation
+14. **Git remote / push は必ず SSH を使う**: このPCはHTTPS認証情報を持たず、GitHubへはSSH鍵で接続している。`git push` 前に origin が SSH 形式（`git@github.com:YusukeHayashiii/hatena-mcp-server.git`）になっていることを確認すること。HTTPS（`https://github.com/...`）になっていたら `git remote set-url origin git@github.com:YusukeHayashiii/hatena-mcp-server.git` で切り替えてからプッシュする。HTTPSのままだと `could not read Username for 'https://github.com'` で失敗する。
+15. **Git identity**: コミット時の author は `YusukeHayashiii <86298092+YusukeHayashiii@users.noreply.github.com>`。未設定（`Author identity unknown`）なら `git config user.name` / `git config user.email` でローカル設定してからコミットする。
 
 ## Steering Configuration
 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ uv run src/hatena_blog_mcp/server.py
 - 再起動後、接続に成功すると `hatena-mcp` のツール群が利用可能になります
 
 3) 動作確認
-- ツール一覧に `create_blog_post`, `update_blog_post`, `get_blog_post`, `list_blog_posts`, `create_blog_post_from_markdown` が表示されること
+- ツール一覧に `create_blog_post`, `update_blog_post`, `get_blog_post`, `list_blog_posts`, `create_blog_post_from_markdown`, `delete_blog_post` が表示されること
 - 例（一覧取得の依頼）:
 ```text
 list_blog_posts(limit=5) を実行してください
@@ -160,7 +160,7 @@ create_blog_post(
 - `limit` (任意): 取得する記事数の上限（デフォルト: 10、最大: 100）
 
 ### `create_blog_post_from_markdown`
-Markdownファイルから記事を投稿します。
+Markdownファイルから記事を投稿します。Front Matter の `draft: true` で下書き投稿に対応します。
 
 **パラメータ:**
 - `path` (必須): Markdownファイルのパス
@@ -170,12 +170,21 @@ Markdownファイルから記事を投稿します。
 ---
 title: 記事のタイトル
 categories: [技術, Python]
+draft: true
 ---
 
 # 記事本文
 
 Markdownで記述された本文がHTMLに変換されます。
 ```
+
+> **下書きフラグについて**: 下書き指定は AtomPub 標準の `<app:control><app:draft>yes</app:draft></app:control>` で送信します（旧実装の `<hatena:draft>` は誤りで下書きが効かず即公開されていたため修正済み）。記事取得時は `app:draft` を優先し、旧 `hatena:draft` もフォールバックで参照します。
+
+### `delete_blog_post`
+指定したIDのブログ記事を削除します。
+
+**パラメータ:**
+- `post_id` (必須): 削除する記事のID（簡単ID・完全IDのどちらも指定可能）
 
 ## 🧪 テスト
 

--- a/src/hatena_blog_mcp/blog_service.py
+++ b/src/hatena_blog_mcp/blog_service.py
@@ -84,6 +84,7 @@ class BlogPostService:
         categories: Optional[List[str]] = None,
         author: Optional[str] = None,
         summary: Optional[str] = None,
+        draft: Optional[bool] = None,
     ) -> BlogPost:
         """記事を新規作成します（content は HTML 想定）。
 
@@ -97,6 +98,7 @@ class BlogPostService:
             categories=categories or [],
             author=author,
             summary=summary,
+            draft=draft,
         )
         entry_xml = self.xml.create_entry_xml(blog_post)
         response = await self.client.post("/entry", entry_xml)
@@ -157,7 +159,8 @@ class BlogPostService:
 
     async def delete_post(self, post_id: str) -> bool:
         """記事を削除します。成功時 True を返します。"""
-        path = f"/entry/{post_id}"
+        numeric_id = self._extract_numeric_id(post_id)
+        path = f"/entry/{numeric_id}"
         response = await self.client.delete(path)
         return response.status_code in (200, 202, 204)
 
@@ -189,6 +192,7 @@ class BlogPostService:
                 categories=blog_post.categories,
                 summary=blog_post.summary,
                 author=blog_post.author,
+                draft=blog_post.draft,
             )
             
         except (FileNotFoundError, ValueError) as e:

--- a/src/hatena_blog_mcp/server.py
+++ b/src/hatena_blog_mcp/server.py
@@ -286,6 +286,37 @@ async def create_blog_post_from_markdown(
     return await _create_blog_post_from_markdown()
 
 
+@mcp.tool()
+async def delete_blog_post(
+    post_id: Annotated[str, "削除する記事のID（簡単ID/完全IDどちらも可）"],
+) -> str:
+    """指定したIDのブログ記事を削除します"""
+
+    from hatena_blog_mcp.error_handler import handle_mcp_errors, validate_required_params
+
+    @handle_mcp_errors
+    async def _delete_blog_post():
+        logger.info(f"Deleting blog post: {post_id}")
+
+        # パラメータ検証
+        params = {"post_id": post_id}
+        validation_error = validate_required_params(params, ["post_id"])
+        if validation_error:
+            raise ValueError(validation_error)
+
+        from hatena_blog_mcp.service_factory import get_blog_service
+
+        service = get_blog_service()
+
+        success = await service.delete_post(post_id)
+
+        if success:
+            return f"🗑️ 記事を削除しました!\n🆔 記事ID: {post_id}"
+        return f"⚠️ 記事の削除に失敗しました。\n🆔 記事ID: {post_id}"
+
+    return await _delete_blog_post()
+
+
 async def cleanup_on_exit():
     """サーバー終了時のクリーンアップ処理"""
     from hatena_blog_mcp.service_factory import cleanup_services

--- a/src/hatena_blog_mcp/xml_processor.py
+++ b/src/hatena_blog_mcp/xml_processor.py
@@ -23,20 +23,25 @@ class AtomPubProcessor:
     # AtomPub名前空間
     ATOM_NS = "http://www.w3.org/2005/Atom"
     HATENA_NS = "http://www.hatena.ne.jp/info/xmlns#"
-    
+    APP_NS = "http://www.w3.org/2007/app"
+
     # 名前空間マップ
     NSMAP = {
         None: ATOM_NS,  # デフォルト名前空間
-        "hatena": HATENA_NS
+        "hatena": HATENA_NS,
+        "app": APP_NS
     }
-    
+
     def __init__(self):
         """AtomPub XMLプロセッサーを初期化します"""
         # ElementMakerを作成（Atom名前空間用）
         self.E = ElementMaker(namespace=self.ATOM_NS, nsmap=self.NSMAP)
-        
+
         # はてな名前空間用のElementMaker
         self.H = ElementMaker(namespace=self.HATENA_NS, nsmap=self.NSMAP)
+
+        # AtomPub control名前空間用のElementMaker（下書きフラグ等）
+        self.A = ElementMaker(namespace=self.APP_NS, nsmap=self.NSMAP)
 
     def create_entry_xml(self, blog_post: BlogPost) -> etree._Element:
         """
@@ -95,11 +100,10 @@ class AtomPubProcessor:
             now = datetime.now(timezone.utc).isoformat()
             entry.append(self.E.updated(now))
         
-        # はてな固有の設定
+        # 下書きフラグ（AtomPub app:control/app:draft）
         if blog_post.draft is not None:
-            # 下書きフラグ
             draft_value = "yes" if blog_post.draft else "no"
-            entry.append(self.H.draft(draft_value))
+            entry.append(self.A.control(self.A.draft(draft_value)))
         
         # ID（更新時のみ）
         if blog_post.id:
@@ -152,7 +156,7 @@ class AtomPubProcessor:
                 raise
 
         # 名前空間を考慮した要素検索用
-        ns = {'atom': self.ATOM_NS, 'hatena': self.HATENA_NS}
+        ns = {'atom': self.ATOM_NS, 'hatena': self.HATENA_NS, 'app': self.APP_NS}
         
         # 必須要素の取得
         title_elem = entry.find('.//atom:title', ns)
@@ -212,8 +216,10 @@ class AtomPubProcessor:
             except ValueError:
                 logger.warning(f"更新日時の解析に失敗: {updated_elem.text}")
         
-        # 下書きフラグ（はてな固有）
-        draft_elem = entry.find('.//hatena:draft', ns)
+        # 下書きフラグ（AtomPub app:control/app:draft、旧hatena:draftもフォールバックで参照）
+        draft_elem = entry.find('.//app:control/app:draft', ns)
+        if draft_elem is None:
+            draft_elem = entry.find('.//hatena:draft', ns)
         if draft_elem is not None and draft_elem.text:
             blog_post.draft = draft_elem.text.lower() == "yes"
         
@@ -282,7 +288,7 @@ class AtomPubProcessor:
                 raise
 
         # 名前空間を考慮した要素検索用
-        ns = {'atom': self.ATOM_NS, 'hatena': self.HATENA_NS}
+        ns = {'atom': self.ATOM_NS, 'hatena': self.HATENA_NS, 'app': self.APP_NS}
         
         # エントリ要素を全て取得
         entry_elems = feed.findall('.//atom:entry', ns)

--- a/tests/unit/test_xml_processor.py
+++ b/tests/unit/test_xml_processor.py
@@ -48,9 +48,9 @@ class TestAtomPubProcessor:
         
         # XML要素の存在確認
         assert entry.tag == f"{{{processor.ATOM_NS}}}entry"
-        
+
         # 名前空間設定
-        ns = {'atom': processor.ATOM_NS, 'hatena': processor.HATENA_NS}
+        ns = {'atom': processor.ATOM_NS, 'hatena': processor.HATENA_NS, 'app': processor.APP_NS}
         
         # タイトル
         title = entry.find('.//atom:title', ns)
@@ -90,8 +90,8 @@ class TestAtomPubProcessor:
         assert updated is not None
         assert "2024-01-02T15:30:00" in updated.text
         
-        # 下書きフラグ
-        draft = entry.find('.//hatena:draft', ns)
+        # 下書きフラグ（AtomPub app:control/app:draft）
+        draft = entry.find('.//app:control/app:draft', ns)
         assert draft is not None
         assert draft.text == "no"
 
@@ -126,9 +126,9 @@ class TestAtomPubProcessor:
         )
         
         entry = processor.create_entry_xml(draft_post)
-        
-        ns = {'atom': processor.ATOM_NS, 'hatena': processor.HATENA_NS}
-        draft = entry.find('.//hatena:draft', ns)
+
+        ns = {'atom': processor.ATOM_NS, 'hatena': processor.HATENA_NS, 'app': processor.APP_NS}
+        draft = entry.find('.//app:control/app:draft', ns)
         assert draft is not None
         assert draft.text == "yes"
 


### PR DESCRIPTION
## 概要
MCPサーバーの修正と機能追加、および関連ドキュメントの反映。

## 変更内容
### 機能追加
- **`delete_blog_post` ツール追加** (`server.py`): 指定IDの記事を削除。簡単ID/完全IDの両方に対応。
- `blog_service.delete_post`: ID正規化（`_extract_numeric_id`）を追加。

### バグ修正
- **下書きフラグをAtomPub標準形式へ修正** (`xml_processor.py`): 旧 `<hatena:draft>`（誤・下書きが効かず即公開されていた）を `<app:control><app:draft>`（正）に変更。取得時は `app:draft` を優先し、旧 `hatena:draft` もフォールバック参照。
- `blog_service.create_post` とMarkdown投稿経路に `draft` を透過。

### ドキュメント
- `README.md`: ツール一覧に `delete_blog_post` を追記、説明セクションとdraft修正の注記を追加。
- `.kiro/specs/.../design.md`: 公開ツール表に `delete_blog_post` を追記。
- `CLAUDE.md`: SSH限定push運用とgit identityをDevelopment Rulesに明記。

## テスト
- `uv run python -m pytest tests/unit/` — 132 passed ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)